### PR TITLE
Docker Compose (Fix)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,17 +1,29 @@
+# Use Eclipse Temurin OpenJDK to build the application
 FROM eclipse-temurin:17-jdk-alpine as build
 WORKDIR /workspace/app
 
 COPY mvnw .
-COPY .mvn .mvn
+COPY .mvn/ .mvn/
+
+# Ensure mvnw script has LF line endings and is executable
+RUN apk add --no-cache dos2unix && \
+    dos2unix ./mvnw && \
+    chmod +x ./mvnw
+
 COPY pom.xml .
 COPY src src
 
 RUN ./mvnw install -DskipTests
+
+# Prepare the application for running
 RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*.jar)
 
+# Use Eclipse Temurin OpenJDK to run the application
 FROM eclipse-temurin:17-jdk-alpine
 VOLUME /tmp
 ARG DEPENDENCY=/workspace/app/target/dependency
+
+# Copy application JAR and dependencies from the build stage
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app


### PR DESCRIPTION
apk add --no-cache dos2unix: Installs the dos2unix utility without caching the package to save space. This utility is used to convert files with Windows line endings (CRLF) to Unix/Linux line endings (LF).

dos2unix ./mvnw: Converts the line endings of the mvnw script from CRLF to LF, making it compatible with Unix/Linux systems.

chmod +x ./mvnw: Changes the permission of the mvnw script to make it executable. This step is necessary for running the script in Unix/Linux environments.